### PR TITLE
Add dir='rtl' div to README markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Fibonacci:
 
 
 FizzBuzz source:
+
+<div dir="rtl">
+
 ```
 امر عامل قاسمــمع٣ (ن) ليسوي
    د = ن ٪ ٣
@@ -89,8 +92,11 @@ FizzBuzz source:
 بس
 ```
 
+</div>
 
 Fibonacci source:
+
+<div dir="rtl">
 ```
 امر عامل فب (ن) ليسوي
     د = ٠
@@ -112,3 +118,4 @@ Fibonacci source:
 
 اطبع (فب(١٥))
 ```
+</div>

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ FizzBuzz source:
 Fibonacci source:
 
 <div dir="rtl">
+   
 ```
 امر عامل فب (ن) ليسوي
     د = ٠
@@ -118,4 +119,5 @@ Fibonacci source:
 
 اطبع (فب(١٥))
 ```
+
 </div>


### PR DESCRIPTION
This makes the lines of code formatted correctly right-to-left in the README on GitHub. Sample:

<div dir="rtl">

 ```
 امر عامل قاسمــمع٣ (ن) ليسوي
    د = ن ٪ ٣
```

</div>